### PR TITLE
Added title to fa icons in 'who are we'

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -196,32 +196,32 @@
                     <ul class="major-icons">
                         <li>
                             <a href="PublicRelations.html">
-                                <div class="echo"><span class="icon style1 major fa-heart"></span></div>
+                                <div class="echo"><span title="Public Relations" class="icon style1 major fa-heart"></span></div>
                             </a>
                         </li>
                         <li>
                             <a href="Leadership.html">
-                                <div class="echo"><span class="icon style2 major fa-cogs"></span></div>
+                                <div class="echo"><span title="Leadership" class="icon style2 major fa-cogs"></span></div>
                             </a>
                         </li>
                         <li>
                             <a href="Calendar.html">
-                                <div class="echo"><span class="icon style3 major fa-calendar"></span></div>
+                                <div class="echo"><span title="Calendar" class="icon style3 major fa-calendar"></span></div>
                             </a>
                         </li>
                         <li>
                             <a href="Membership.html">
-                                <div class="echo"><span class="icon style4 major fa-users"></span></div>
+                                <div class="echo"><span title="Membership" class="icon style4 major fa-users"></span></div>
                             </a>
                         </li>
                         <li>
                             <a href="ImagineRIT.html">
-                                <div class="echo"><span class="icon style5 major fa-wrench"></span></div>
+                                <div class="echo"><span title="ImagineRIT" class="icon style5 major fa-wrench"></span></div>
                             </a>
                         </li>
                         <li>
                             <a href="VirtualTour.html">
-                                <div class="echo"><span class="icon style6 major fa-map-marker"></span></div>
+                                <div class="echo"><span title="Virtual Tour" class="icon style6 major fa-map-marker"></span></div>
                             </a>
                         </li>
                     </ul>


### PR DESCRIPTION
Small change, shouldn't break anything.
Just added title="Description" in each of the spans which define the FA icons around line 192 of index.
Works on manual test of site.
![Screenshot 2019-03-21 at 19 39 42](https://user-images.githubusercontent.com/18663807/54791633-25922300-4c11-11e9-91f3-1dd05933cead.png)
